### PR TITLE
Set it to enforce app extension safe API only

### DIFF
--- a/ReadabilityKit.xcodeproj/project.pbxproj
+++ b/ReadabilityKit.xcodeproj/project.pbxproj
@@ -716,6 +716,7 @@
 		57156D661D632539008A9C49 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -740,6 +741,7 @@
 		57156D671D632539008A9C49 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;


### PR DESCRIPTION
So it can be used inside iOS app extensions etc. 👌 
