### PR TITLE
Fixing watchOS platform version from Swift Package manifest

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Ji",
+        "repositoryURL": "https://github.com/honghaoz/Ji",
+        "state": {
+          "branch": null,
+          "revision": "a37a310cc6aaf999de4bee953a9680bf9b629200",
+          "version": "5.1.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     platforms: [
         .macOS(.v10_12),
         .iOS(.v10),
-        .watchOS(v3),
+        .watchOS(.v3),
         .tvOS(.v10)
     ],
     products: [

--- a/Sources/Readability.swift
+++ b/Sources/Readability.swift
@@ -24,6 +24,7 @@
 //
 
 import Ji
+@_exported import Foundation
 
 public struct ReadabilityData {
 	public let title: String


### PR DESCRIPTION
#42 

- PR Description
This pull request fixes this issue related to importing `ReadabilityKit` as a Swift Package dependency. The `Package.swift` file which watchOS plataform was defined, has `v3` mistyped insted of `.v3`.

- Evidence
After typo correction, my consumer project was able to proper reference the package.

<img width="429" alt="Screenshot 2023-01-19 at 13 38 04" src="https://user-images.githubusercontent.com/11509104/213506523-5d6e7a61-918e-43d5-9f42-0c08a6e9dd96.png">
